### PR TITLE
유저 등급 순 후기 정렬 및 팔로잉 유저 후기 필터링 구현

### DIFF
--- a/src/main/java/com/b6/mypaldotrip/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/review/controller/ReviewController.java
@@ -39,8 +39,11 @@ public class ReviewController {
 
     @GetMapping
     public ResponseEntity<RestResponse<List<ReviewListRes>>> getReviewList(
-            @PathVariable Long tripId, @RequestBody ReviewListReq req) {
-        List<ReviewListRes> res = reviewService.getReviewList(tripId, req);
+            @PathVariable Long tripId,
+            @RequestBody ReviewListReq req,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        Long userId = userDetails != null ? userDetails.getUserEntity().getUserId() : null;
+        List<ReviewListRes> res = reviewService.getReviewList(tripId, req, userId);
         return RestResponse.success(res, GlobalResultCode.SUCCESS, versionConfig.getVersion())
                 .toResponseEntity();
     }

--- a/src/main/java/com/b6/mypaldotrip/domain/review/controller/dto/request/ReviewListReq.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/review/controller/dto/request/ReviewListReq.java
@@ -2,4 +2,4 @@ package com.b6.mypaldotrip.domain.review.controller.dto.request;
 
 import com.b6.mypaldotrip.domain.review.store.entity.ReviewSort;
 
-public record ReviewListReq(ReviewSort reviewSort, int page) {}
+public record ReviewListReq(boolean filterByFollowing, ReviewSort reviewSort, int page) {}

--- a/src/main/java/com/b6/mypaldotrip/domain/review/controller/dto/response/ReviewListRes.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/review/controller/dto/response/ReviewListRes.java
@@ -5,4 +5,4 @@ import lombok.Builder;
 
 @Builder
 public record ReviewListRes(
-        String username, String content, Integer score, LocalDateTime modifiedAt) {}
+        String username, Long level, String content, Integer score, LocalDateTime modifiedAt) {}

--- a/src/main/java/com/b6/mypaldotrip/domain/review/service/ReviewService.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/review/service/ReviewService.java
@@ -49,11 +49,15 @@ public class ReviewService {
                 .build();
     }
 
-    public List<ReviewListRes> getReviewList(Long tripId, ReviewListReq req) {
+    public List<ReviewListRes> getReviewList(Long tripId, ReviewListReq req, Long userId) {
         Pageable pageable = PageRequest.of(req.page(), 20);
         ReviewSort sort = (req.reviewSort() != null) ? req.reviewSort() : ReviewSort.MODIFIED;
+        boolean isFollowingOnly = req.filterByFollowing();
         tripService.findTrip(tripId);
-        return reviewRepository.findByTripId(tripId, sort, pageable).stream()
+
+        return reviewRepository
+                .findByTripIdAndSort(tripId, userId, isFollowingOnly, sort, pageable)
+                .stream()
                 .map(
                         review ->
                                 ReviewListRes.builder()

--- a/src/main/java/com/b6/mypaldotrip/domain/review/service/ReviewService.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/review/service/ReviewService.java
@@ -58,6 +58,7 @@ public class ReviewService {
                         review ->
                                 ReviewListRes.builder()
                                         .username(review.getUser().getUsername())
+                                        .level(review.getUser().getLevel())
                                         .content(review.getContent())
                                         .score(review.getScore())
                                         .modifiedAt(review.getModifiedAt())

--- a/src/main/java/com/b6/mypaldotrip/domain/review/store/entity/ReviewSort.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/review/store/entity/ReviewSort.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 public enum ReviewSort {
     MODIFIED,
     RATING,
-    GRADE,
+    LEVEL,
     FOLLOW;
 
     @JsonCreator

--- a/src/main/java/com/b6/mypaldotrip/domain/review/store/repository/ReviewCustomRepository.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/review/store/repository/ReviewCustomRepository.java
@@ -8,5 +8,10 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewCustomRepository {
-    List<ReviewEntity> findByTripId(Long tripId, ReviewSort reviewSort, Pageable pageable);
+    List<ReviewEntity> findByTripIdAndSort(
+            Long tripId,
+            Long userId,
+            boolean isFollowingOnly,
+            ReviewSort reviewSort,
+            Pageable pageable);
 }

--- a/src/main/java/com/b6/mypaldotrip/domain/review/store/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/review/store/repository/ReviewRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.b6.mypaldotrip.domain.review.store.repository;
 
+import com.b6.mypaldotrip.domain.follow.store.entity.QFollowingEntity;
 import com.b6.mypaldotrip.domain.review.exception.ReviewErrorCode;
 import com.b6.mypaldotrip.domain.review.store.entity.QReviewEntity;
 import com.b6.mypaldotrip.domain.review.store.entity.ReviewEntity;
@@ -9,6 +10,7 @@ import com.b6.mypaldotrip.domain.user.store.entity.QUserEntity;
 import com.b6.mypaldotrip.global.exception.GlobalException;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,23 +25,43 @@ public class ReviewRepositoryImpl implements ReviewCustomRepository {
     QReviewEntity review = QReviewEntity.reviewEntity;
     QUserEntity user = QUserEntity.userEntity;
     QTripEntity trip = QTripEntity.tripEntity;
+    QFollowingEntity following = QFollowingEntity.followingEntity;
 
     @Override
-    public List<ReviewEntity> findByTripId(Long tripId, ReviewSort reviewSort, Pageable pageable) {
-        BooleanExpression checkTripId = review.trip.tripId.eq(tripId);
+    public List<ReviewEntity> findByTripIdAndSort(
+            Long tripId,
+            Long userId,
+            boolean isFollowingOnly,
+            ReviewSort reviewSort,
+            Pageable pageable) {
+        BooleanExpression eqTripId = review.trip.tripId.eq(tripId);
+        BooleanExpression getFollowingUser = findFollowingUserIdList(userId, isFollowingOnly);
+
         return jpaQueryFactory
                 .selectFrom(review)
                 .join(review.user, user)
                 .fetchJoin()
                 .join(review.trip, trip)
-                .where(checkTripId)
+                .where(eqTripId, getFollowingUser)
                 .orderBy(checkReviewSort(reviewSort))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
     }
 
-    public OrderSpecifier<?> checkReviewSort(ReviewSort reviewSort) {
+    private BooleanExpression findFollowingUserIdList(Long userId, boolean isFollowingOnly) {
+        BooleanExpression getFollowingUser = null;
+        if (isFollowingOnly && userId != null) {
+            getFollowingUser =
+                    review.user.userId.in(
+                            JPAExpressions.select(following.followingUser.userId)
+                                    .from(following)
+                                    .where(following.user.userId.eq(userId)));
+        }
+        return getFollowingUser;
+    }
+
+    private OrderSpecifier<?> checkReviewSort(ReviewSort reviewSort) {
         switch (reviewSort) {
             case MODIFIED -> {
                 return review.modifiedAt.desc();

--- a/src/main/java/com/b6/mypaldotrip/domain/review/store/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/review/store/repository/ReviewRepositoryImpl.java
@@ -10,10 +10,11 @@ import com.b6.mypaldotrip.global.exception.GlobalException;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -46,6 +47,9 @@ public class ReviewRepositoryImpl implements ReviewCustomRepository {
             }
             case RATING -> {
                 return review.score.desc();
+            }
+            case LEVEL -> {
+                return user.level.desc();
             }
             default -> throw new GlobalException(ReviewErrorCode.WRONG_REVIEW_SORT);
         }

--- a/src/main/java/com/b6/mypaldotrip/domain/review/store/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/review/store/repository/ReviewRepositoryImpl.java
@@ -10,11 +10,10 @@ import com.b6.mypaldotrip.global.exception.GlobalException;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor


### PR DESCRIPTION
## 개요

후기 정렬 기능

## 작업사항

- 유저 등급 순 후기 정렬 기능
- 팔로잉 유저 후기 필터링 기능
  
## 변경로직

- 팔로잉 유저 후기 필터링 기능:
  쿼리를 두번 실행했던 기존 방식 -> BooleanExpression과 JPAExpressions 이용
  결과적으로 쿼리 횟수 줄이는데 성공했습니다

## 관련 이슈
- close #45 