### PR TITLE
유저 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/b6/mypaldotrip/domain/follow/store/entity/FollowerEntity.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/follow/store/entity/FollowerEntity.java
@@ -2,6 +2,7 @@ package com.b6.mypaldotrip.domain.follow.store.entity;
 
 import com.b6.mypaldotrip.domain.user.store.entity.UserEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,11 +24,11 @@ public class FollowerEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long followerId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private UserEntity user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "followed_user_id")
     private UserEntity followedUser;
 

--- a/src/main/java/com/b6/mypaldotrip/domain/follow/store/entity/FollowingEntity.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/follow/store/entity/FollowingEntity.java
@@ -2,6 +2,7 @@ package com.b6.mypaldotrip.domain.follow.store.entity;
 
 import com.b6.mypaldotrip.domain.user.store.entity.UserEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,11 +24,11 @@ public class FollowingEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long followingId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private UserEntity user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "following_user_id")
     private UserEntity followingUser;
 

--- a/src/main/java/com/b6/mypaldotrip/domain/user/controller/UserController.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/user/controller/UserController.java
@@ -1,9 +1,11 @@
 package com.b6.mypaldotrip.domain.user.controller;
 
+import com.b6.mypaldotrip.domain.user.controller.dto.request.UserListReq;
 import com.b6.mypaldotrip.domain.user.controller.dto.request.UserSignUpReq;
 import com.b6.mypaldotrip.domain.user.controller.dto.request.UserUpdateReq;
 import com.b6.mypaldotrip.domain.user.controller.dto.response.UserDeleteRes;
 import com.b6.mypaldotrip.domain.user.controller.dto.response.UserGetProfileRes;
+import com.b6.mypaldotrip.domain.user.controller.dto.response.UserListRes;
 import com.b6.mypaldotrip.domain.user.controller.dto.response.UserSignUpRes;
 import com.b6.mypaldotrip.domain.user.controller.dto.response.UserUpdateRes;
 import com.b6.mypaldotrip.domain.user.service.UserService;
@@ -13,6 +15,7 @@ import com.b6.mypaldotrip.global.response.RestResponse;
 import com.b6.mypaldotrip.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -67,6 +70,14 @@ public class UserController {
         UserUpdateRes res =
                 userService.updateProfile(
                         multipartFile, req, userDetails.getUserEntity().getUserId());
+        return RestResponse.success(res, GlobalResultCode.SUCCESS, versionConfig.getVersion())
+                .toResponseEntity();
+    }
+
+    @GetMapping
+    public ResponseEntity<RestResponse<List<UserListRes>>> getUserList(
+            @RequestBody UserListReq req, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<UserListRes> res = userService.getUserList(req, userDetails);
         return RestResponse.success(res, GlobalResultCode.SUCCESS, versionConfig.getVersion())
                 .toResponseEntity();
     }

--- a/src/main/java/com/b6/mypaldotrip/domain/user/controller/dto/request/UserListReq.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/user/controller/dto/request/UserListReq.java
@@ -1,0 +1,15 @@
+package com.b6.mypaldotrip.domain.user.controller.dto.request;
+
+import com.b6.mypaldotrip.domain.user.store.entity.UserRole;
+import com.b6.mypaldotrip.domain.user.store.entity.UserSort;
+
+public record UserListReq(
+        int page,
+        int size,
+        boolean asc,
+        UserSort userSort,
+        Long ageCondition,
+        Long levelCondition,
+        UserRole userRoleCondition,
+        Boolean followerCondition,
+        Boolean followingCondition) {}

--- a/src/main/java/com/b6/mypaldotrip/domain/user/controller/dto/response/UserListRes.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/user/controller/dto/response/UserListRes.java
@@ -1,0 +1,14 @@
+package com.b6.mypaldotrip.domain.user.controller.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record UserListRes(
+        Long userId,
+        String email,
+        String username,
+        Long age,
+        Long level,
+        String userRoleValue,
+        int writeReviewCnt,
+        int followerCnt) {}

--- a/src/main/java/com/b6/mypaldotrip/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/user/exception/UserErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ResultCode {
     NOT_FOUND_USER_BY_EMAIL(HttpStatus.BAD_REQUEST, "해당 이메일로 가입된 유저는 없습니다."),
     NOT_FOUND_USER_BY_USERID(HttpStatus.BAD_REQUEST, "해당 id에 해당하는 유저는 없습니다."),
-    BEFORE_EMAIL_VALIDATION(HttpStatus.PRECONDITION_FAILED, "해당 이메일은 인증코드를 받아 검증 받지 않은 상태입니다.");
+    BEFORE_EMAIL_VALIDATION(HttpStatus.PRECONDITION_FAILED, "해당 이메일은 인증코드를 받아 검증 받지 않은 상태입니다."),
+    WRONG_USER_SORT(HttpStatus.BAD_REQUEST, "잘못된 유저 정렬 방식 입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/b6/mypaldotrip/domain/user/service/UserService.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/user/service/UserService.java
@@ -1,9 +1,11 @@
 package com.b6.mypaldotrip.domain.user.service;
 
+import com.b6.mypaldotrip.domain.user.controller.dto.request.UserListReq;
 import com.b6.mypaldotrip.domain.user.controller.dto.request.UserSignUpReq;
 import com.b6.mypaldotrip.domain.user.controller.dto.request.UserUpdateReq;
 import com.b6.mypaldotrip.domain.user.controller.dto.response.UserDeleteRes;
 import com.b6.mypaldotrip.domain.user.controller.dto.response.UserGetProfileRes;
+import com.b6.mypaldotrip.domain.user.controller.dto.response.UserListRes;
 import com.b6.mypaldotrip.domain.user.controller.dto.response.UserSignUpRes;
 import com.b6.mypaldotrip.domain.user.controller.dto.response.UserUpdateRes;
 import com.b6.mypaldotrip.domain.user.exception.UserErrorCode;
@@ -11,7 +13,9 @@ import com.b6.mypaldotrip.domain.user.store.entity.UserEntity;
 import com.b6.mypaldotrip.domain.user.store.repository.UserRepository;
 import com.b6.mypaldotrip.global.common.S3Provider;
 import com.b6.mypaldotrip.global.exception.GlobalException;
+import com.b6.mypaldotrip.global.security.UserDetailsImpl;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -100,6 +104,25 @@ public class UserService {
         return userRepository
                 .findById(userId)
                 .orElseThrow(() -> new GlobalException(UserErrorCode.NOT_FOUND_USER_BY_USERID));
+    }
+
+    public List<UserListRes> getUserList(UserListReq req, UserDetailsImpl userDetails) {
+
+        List<UserEntity> userEntityList = userRepository.findByDynamicConditions(req, userDetails);
+        return userEntityList.stream()
+            .map(
+                userEntity ->
+                    UserListRes.builder()
+                        .userId(userEntity.getUserId())
+                        .email(userEntity.getEmail())
+                        .username(userEntity.getUsername())
+                        .age(userEntity.getAge())
+                        .level(userEntity.getLevel())
+                        .userRoleValue(userEntity.getUserRole().getValue())
+                        .writeReviewCnt(userEntity.getReviewList().size())
+                        .followerCnt(userEntity.getFollowerList().size())
+                        .build())
+            .toList();
     }
 
     public void acceptApplication(UserEntity userEntity) {

--- a/src/main/java/com/b6/mypaldotrip/domain/user/service/UserService.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/user/service/UserService.java
@@ -110,19 +110,19 @@ public class UserService {
 
         List<UserEntity> userEntityList = userRepository.findByDynamicConditions(req, userDetails);
         return userEntityList.stream()
-            .map(
-                userEntity ->
-                    UserListRes.builder()
-                        .userId(userEntity.getUserId())
-                        .email(userEntity.getEmail())
-                        .username(userEntity.getUsername())
-                        .age(userEntity.getAge())
-                        .level(userEntity.getLevel())
-                        .userRoleValue(userEntity.getUserRole().getValue())
-                        .writeReviewCnt(userEntity.getReviewList().size())
-                        .followerCnt(userEntity.getFollowerList().size())
-                        .build())
-            .toList();
+                .map(
+                        userEntity ->
+                                UserListRes.builder()
+                                        .userId(userEntity.getUserId())
+                                        .email(userEntity.getEmail())
+                                        .username(userEntity.getUsername())
+                                        .age(userEntity.getAge())
+                                        .level(userEntity.getLevel())
+                                        .userRoleValue(userEntity.getUserRole().getValue())
+                                        .writeReviewCnt(userEntity.getReviewList().size())
+                                        .followerCnt(userEntity.getFollowerList().size())
+                                        .build())
+                .toList();
     }
 
     public void acceptApplication(UserEntity userEntity) {

--- a/src/main/java/com/b6/mypaldotrip/domain/user/store/entity/UserEntity.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/user/store/entity/UserEntity.java
@@ -15,7 +15,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -49,10 +51,10 @@ public class UserEntity extends BaseEntity {
     private UserRole userRole;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ReviewEntity> reviewList = new ArrayList<>();
+    private Set<ReviewEntity> reviewList = new LinkedHashSet<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<FollowerEntity> followerList = new ArrayList<>();
+    private Set<FollowerEntity> followerList = new LinkedHashSet<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FollowingEntity> followingList = new ArrayList<>();

--- a/src/main/java/com/b6/mypaldotrip/domain/user/store/entity/UserSort.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/user/store/entity/UserSort.java
@@ -1,0 +1,23 @@
+package com.b6.mypaldotrip.domain.user.store.entity;
+
+import com.b6.mypaldotrip.domain.user.exception.UserErrorCode;
+import com.b6.mypaldotrip.global.exception.GlobalException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum UserSort {
+    MODIFIED,
+    AGE,
+    LEVEL,
+    WRITE_REVIEW_CNT,
+    FOLLOWER_CNT;
+
+    @JsonCreator
+    public static UserSort forValue(String value) {
+        for (UserSort userSort : UserSort.values()) {
+            if (userSort.name().equalsIgnoreCase(value)) {
+                return userSort;
+            }
+        }
+        throw new GlobalException(UserErrorCode.WRONG_USER_SORT);
+    }
+}

--- a/src/main/java/com/b6/mypaldotrip/domain/user/store/repository/UserCustomRepository.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/user/store/repository/UserCustomRepository.java
@@ -1,0 +1,13 @@
+package com.b6.mypaldotrip.domain.user.store.repository;
+
+import com.b6.mypaldotrip.domain.user.controller.dto.request.UserListReq;
+import com.b6.mypaldotrip.domain.user.store.entity.UserEntity;
+import com.b6.mypaldotrip.global.security.UserDetailsImpl;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserCustomRepository {
+
+    List<UserEntity> findByDynamicConditions(UserListReq req, UserDetailsImpl userDetails);
+}

--- a/src/main/java/com/b6/mypaldotrip/domain/user/store/repository/UserCustomRepositoryImpl.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/user/store/repository/UserCustomRepositoryImpl.java
@@ -87,8 +87,9 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
         if (userDetails == null) return null;
         UserEntity loggedUser = userDetails.getUserEntity();
         return followerCondition != null
-                ? userEntity.followerList.contains(
-                        JPAExpressions.selectFrom(followerEntity)
+                ? userEntity.eqAny(
+                        JPAExpressions.select(followerEntity.followedUser)
+                                .from(followerEntity)
                                 .where(followerEntity.user.eq(loggedUser)))
                 : null;
     }
@@ -98,8 +99,9 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
         if (userDetails == null) return null;
         UserEntity loggedUser = userDetails.getUserEntity();
         return followingCondition != null
-                ? userEntity.followingList.contains(
-                        JPAExpressions.selectFrom(followingEntity)
+                ? userEntity.eqAny(
+                        JPAExpressions.select(followingEntity.followingUser)
+                                .from(followingEntity)
                                 .where(followingEntity.user.eq(loggedUser)))
                 : null;
     }

--- a/src/main/java/com/b6/mypaldotrip/domain/user/store/repository/UserCustomRepositoryImpl.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/user/store/repository/UserCustomRepositoryImpl.java
@@ -1,0 +1,106 @@
+package com.b6.mypaldotrip.domain.user.store.repository;
+
+import static com.b6.mypaldotrip.domain.follow.store.entity.QFollowerEntity.followerEntity;
+import static com.b6.mypaldotrip.domain.follow.store.entity.QFollowingEntity.followingEntity;
+import static com.b6.mypaldotrip.domain.user.store.entity.QUserEntity.userEntity;
+
+import com.b6.mypaldotrip.domain.user.controller.dto.request.UserListReq;
+import com.b6.mypaldotrip.domain.user.store.entity.UserEntity;
+import com.b6.mypaldotrip.domain.user.store.entity.UserRole;
+import com.b6.mypaldotrip.domain.user.store.entity.UserSort;
+import com.b6.mypaldotrip.global.security.UserDetailsImpl;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<UserEntity> findByDynamicConditions(UserListReq req, UserDetailsImpl userDetails) {
+        Pageable pageable = PageRequest.of(req.page(), req.size());
+
+        return jpaQueryFactory
+                .selectFrom(userEntity)
+                .leftJoin(userEntity.reviewList)
+                .fetchJoin()
+                .leftJoin(userEntity.followerList)
+                .fetchJoin()
+                .where(
+                        ageEq(req.ageCondition()),
+                        levelEq(req.levelCondition()),
+                        userRoleEq(req.userRoleCondition()),
+                        existFollowerCondition(req.followerCondition(), userDetails),
+                        existFollowingCondition(req.followingCondition(), userDetails))
+                .orderBy(sortCondition(req.userSort(), req.asc()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private OrderSpecifier<?> sortCondition(UserSort userSort, Boolean isAsc) {
+        userSort = userSort != null ? userSort : UserSort.MODIFIED;
+        Order order = isAsc ? Order.ASC : Order.DESC;
+        switch (userSort) {
+            case AGE -> {
+                return new OrderSpecifier<>(order, userEntity.age);
+            }
+            case LEVEL -> {
+                return new OrderSpecifier<>(order, userEntity.level);
+            }
+            case WRITE_REVIEW_CNT -> {
+                return new OrderSpecifier<>(order, userEntity.reviewList.size());
+            }
+            case FOLLOWER_CNT -> {
+                return new OrderSpecifier<>(order, userEntity.followerList.size());
+            }
+            default -> {
+                return new OrderSpecifier<>(order, userEntity.modifiedAt);
+            }
+        }
+    }
+
+    private BooleanExpression ageEq(Long ageCondition) {
+        return ageCondition != null ? userEntity.age.eq(ageCondition) : null;
+    }
+
+    private BooleanExpression levelEq(Long levelCondition) {
+        return levelCondition != null ? userEntity.level.eq(levelCondition) : null;
+    }
+
+    private BooleanExpression userRoleEq(UserRole userRole) {
+        return userRole != null ? userEntity.userRole.eq(userRole) : null;
+    }
+
+    private BooleanExpression existFollowerCondition(
+            Boolean followerCondition, UserDetailsImpl userDetails) {
+        if (userDetails == null) return null;
+        UserEntity loggedUser = userDetails.getUserEntity();
+        return followerCondition != null
+                ? userEntity.followerList.contains(
+                        JPAExpressions.selectFrom(followerEntity)
+                                .where(followerEntity.user.eq(loggedUser)))
+                : null;
+    }
+
+    private BooleanExpression existFollowingCondition(
+            Boolean followingCondition, UserDetailsImpl userDetails) {
+        if (userDetails == null) return null;
+        UserEntity loggedUser = userDetails.getUserEntity();
+        return followingCondition != null
+                ? userEntity.followingList.contains(
+                        JPAExpressions.selectFrom(followingEntity)
+                                .where(followingEntity.user.eq(loggedUser)))
+                : null;
+    }
+}

--- a/src/main/java/com/b6/mypaldotrip/domain/user/store/repository/UserRepository.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/user/store/repository/UserRepository.java
@@ -4,7 +4,7 @@ import com.b6.mypaldotrip.domain.user.store.entity.UserEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<UserEntity, Long> {
+public interface UserRepository extends JpaRepository<UserEntity, Long>, UserCustomRepository {
 
     Optional<UserEntity> findByEmail(String email);
 }

--- a/src/main/java/com/b6/mypaldotrip/domain/user/store/repository/UserRepository.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/user/store/repository/UserRepository.java
@@ -3,7 +3,9 @@ package com.b6.mypaldotrip.domain.user.store.repository;
 import com.b6.mypaldotrip.domain.user.store.entity.UserEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.RepositoryDefinition;
 
+@RepositoryDefinition(domainClass = UserEntity.class, idClass = Long.class)
 public interface UserRepository extends JpaRepository<UserEntity, Long>, UserCustomRepository {
 
     Optional<UserEntity> findByEmail(String email);

--- a/src/main/java/com/b6/mypaldotrip/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/b6/mypaldotrip/global/config/WebSecurityConfig.java
@@ -72,6 +72,10 @@ public class WebSecurityConfig {
                                 .permitAll()
                                 .requestMatchers("/kakao-login/**")
                                 .permitAll()
+                                .requestMatchers(
+                                        HttpMethod.GET,
+                                        "/api/" + versionConfig.getVersion() + "/users/**")
+                                .permitAll()
                                 .anyRequest()
                                 .authenticated());
         http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);


### PR DESCRIPTION
## 개요

유저 목록 조회 기능 구현 ( 정렬 5개 중 하나 적용 가능, 동적 필터 5개)

## 작업사항

- 유저 목록 조회 시 5가지 정렬 구현
- 유저 목록 조회 시 5가지 동적 필터 구현

## 변경로직

- 팔로우 관련 지연로딩 설정

## 관련 이슈
- close #26 
