### PR TITLE
댓글 생성, 목록조회 반환값 추가

### DIFF
--- a/src/main/java/com/b6/mypaldotrip/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/comment/controller/CommentController.java
@@ -13,6 +13,7 @@ import com.b6.mypaldotrip.global.common.GlobalResultCode;
 import com.b6.mypaldotrip.global.config.VersionConfig;
 import com.b6.mypaldotrip.global.response.RestResponse;
 import com.b6.mypaldotrip.global.security.UserDetailsImpl;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -38,7 +39,7 @@ public class CommentController {
     @PostMapping
     public ResponseEntity<RestResponse<CommentSaveRes>> saveComment(
             @PathVariable Long courseId,
-            @RequestBody CommentSaveReq req,
+            @Valid @RequestBody CommentSaveReq req,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         CommentSaveRes res = commentService.saveComment(courseId, req, userDetails.getUserEntity());
 
@@ -74,7 +75,7 @@ public class CommentController {
     public ResponseEntity<RestResponse<CommentUpdateRes>> updateComment(
             @PathVariable Long courseId,
             @PathVariable Long commentId,
-            @RequestBody CommentUpdateReq req,
+            @Valid @RequestBody CommentUpdateReq req,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         CommentUpdateRes res =
                 commentService.updateComment(courseId, commentId, req, userDetails.getUserEntity());

--- a/src/main/java/com/b6/mypaldotrip/domain/comment/controller/dto/request/CommentUpdateReq.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/comment/controller/dto/request/CommentUpdateReq.java
@@ -1,3 +1,5 @@
 package com.b6.mypaldotrip.domain.comment.controller.dto.request;
 
-public record CommentUpdateReq(String content) {}
+import jakarta.validation.constraints.NotNull;
+
+public record CommentUpdateReq(@NotNull(message = "content가 비었습니다.") String content) {}

--- a/src/main/java/com/b6/mypaldotrip/domain/comment/controller/dto/response/CommentListRes.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/comment/controller/dto/response/CommentListRes.java
@@ -1,6 +1,13 @@
 package com.b6.mypaldotrip.domain.comment.controller.dto.response;
 
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
-public record CommentListRes(Long commentId, String username, String content, int totalPage) {}
+public record CommentListRes(
+        Long commentId,
+        String username,
+        String content,
+        LocalDateTime modifiedAt,
+        Long level,
+        int totalPage) {}

--- a/src/main/java/com/b6/mypaldotrip/domain/comment/service/CommentService.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/comment/service/CommentService.java
@@ -70,6 +70,8 @@ public class CommentService {
                                                 .commentId(c.getCommentId())
                                                 .username(c.getUserEntity().getUsername())
                                                 .content(c.getContent())
+                                                .level(c.getUserEntity().getLevel())
+                                                .modifiedAt(c.getModifiedAt())
                                                 .totalPage(totalPages)
                                                 .build())
                         .toList();


### PR DESCRIPTION
## 개요

댓글 생성, 목록조회 반환값 추가

## 작업사항

- 생성시 content가 비었으면 등록 안되게 수정, 목록조회시 level, modifiedAt 추가

## 변경로직

- 내용을 적어주세요.

## 관련 이슈
- #27 #61 
