### PR TITLE
Feat/fix chat 웹소켓config와 채팅방 시큐리티 모두허용

### DIFF
--- a/src/main/java/com/b6/mypaldotrip/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/b6/mypaldotrip/global/config/WebSecurityConfig.java
@@ -82,7 +82,7 @@ public class WebSecurityConfig {
                                 .requestMatchers(
                                         "/api/"
                                                 + versionConfig.getVersion()
-                                                + "/chat-rooms/chat-page")
+                                                + "/chat-rooms/**")
                                 .permitAll()
                                 .anyRequest()
                                 .authenticated());

--- a/src/main/java/com/b6/mypaldotrip/global/config/WebSocketConfig.java
+++ b/src/main/java/com/b6/mypaldotrip/global/config/WebSocketConfig.java
@@ -25,7 +25,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws").withSockJS();
+        registry.addEndpoint("/ws")
+            .setAllowedOriginPatterns("*")
+            .withSockJS();
     }
 
     @Override

--- a/src/main/resources/templates/chat.html
+++ b/src/main/resources/templates/chat.html
@@ -337,7 +337,7 @@
         );
         document.querySelector('#connected-user-fullname').textContent = nickname;
         findAndDisplayConnectedRooms().then();
-        console.log("토큰"+localStorage.getItem('token'));
+        console.log("토큰"+localStorage.getItem('Authorization'));
         fetch('/api/v1/chat-rooms/users/getRole', {
             headers: {
                 'Authorization': localStorage.getItem('Authorization') // 토큰을 헤더에 포함
@@ -569,6 +569,7 @@
         fetch('/api/v1/chat-rooms/rooms', {
             method: 'POST',
             headers: {
+                'Content-Type': 'application/json',
                 'Authorization': localStorage.getItem('Authorization') // 로컬 스토리지의 토큰 사용
             },
             body: JSON.stringify(roomData)
@@ -592,6 +593,7 @@
         fetch('/api/v1/chat-rooms/rooms/' + chatRoomName, {
             method: 'DELETE',
             headers: {
+                'Content-Type': 'application/json',
                 'Authorization': localStorage.getItem('Authorization')// 인증 토큰 포함
             }
         })
@@ -607,6 +609,7 @@
         fetch(`/api/v1/chat-rooms/chatRooms/${originalRoomName}`, {
             method: 'PUT',
             headers: {
+                'Content-Type': 'application/json',
                 'Authorization': localStorage.getItem('Authorization') // 인증 토큰 포함
             },
             body: JSON.stringify({ newChatRoomName: newRoomName }) // 변경할 채팅방 이름을 JSON 형식으로 전달합니다.


### PR DESCRIPTION
## 개요

웹소켓 config변경
채팅 시큐리티 변경

## 작업사항

- 웹소켓 config에 CORS 정책을 설정해 브라우저가 다른 도메인의 리소스에 접근할 수 있도록 허용했습니다
- 채팅 시큐리티 chat-page를 채팅 관련 모든 기능 허용으로 바꿨습니다.
## 변경로직

-  "/chat-rooms/chat-page" -> "/chat-rooms/**"
-   .setAllowedOriginPatterns("*") 추가


## 관련 이슈
