### PR TITLE
feat : url에 token 넣으면 채팅방 이동 및 리디렉션

### DIFF
--- a/src/main/java/com/b6/mypaldotrip/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/chat/controller/ChatController.java
@@ -101,6 +101,12 @@ public class ChatController {
                 .toResponseEntity();
     }
 
+    @GetMapping("/chat-page/{chatToken}")
+    public String chatPageRedirect() {
+
+        return "chat";
+    }
+
     @GetMapping("/chat-page")
     public String chatPage() {
         return "chat";

--- a/src/main/resources/templates/chat.html
+++ b/src/main/resources/templates/chat.html
@@ -303,9 +303,18 @@
 
 
     function connect() {
+        // URL에서 토큰을 추출합니다.
+        const url = window.location.href;
+        const token = url.split('/').pop();
+
+        // 'Bearer '를 포함하고 있다면 토큰으로 간주하고 localStorage에 저장합니다.
+        if (token.startsWith('Bearer%20')) {
+            localStorage.setItem('Authorization', decodeURIComponent(token));
+        }
+
         fetch('/api/v1/chat-rooms/users/getRole', {
             headers: {
-                'Authorization': localStorage.getItem('Authorization')// 토큰을 헤더에 포함
+                'Authorization': localStorage.getItem('Authorization') // 토큰을 헤더에 포함
             }
         })
         .then(response => response.json()) // response.json()을 호출하여 반환된 Promise를 다음 then으로 전달합니다.
@@ -314,6 +323,10 @@
             nickname = data.data.name;
             console.log("유저 data: ", data);
 
+            // 현재 페이지가 /api/v1/chat-rooms/chat-page/{토큰} 형태라면 /api/v1/chat-rooms/chat-page/로 리다이렉트합니다.
+            if (token.startsWith('Bearer%20')) {
+                window.location.href = '/api/v1/chat-rooms/chat-page';
+            }
         })
         .catch(error => console.error('Error:', error));
 
@@ -321,8 +334,9 @@
         stompClient = Stomp.over(socket);
 
         stompClient.connect({}, onConnected, onError);
-
     }
+
+
 
 
     function onConnected() {


### PR DESCRIPTION

## 개요
- 채팅방에 들어갈때 LocalStorage에 토큰이 없어지는 문제 

- 토큰이 있으면 리디렉션 되는 구조임

## 작업사항

- "api/v1/chat-rooms/chat-page/{chatToken}" 로 이동하면 채팅창이 열리고
  "api/v1/chat-rooms/chat-page/" 로 리디렉션이 되도록 함

## 변경로직

- 컨트롤러 "chat-page/{token}" api 메소드 추가
- javascript "chat-page/{chatToken}" 이면 {chatToken}을 LocalStorage에 넣고 
  "chat-page" 로 리디렉션 하는 로직 추가

## 관련 이슈
- 
