### PR TITLE
코스생성시 연관된 여행정보 없이도 생성 가능, RestDocs 아스키독 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -25,6 +25,31 @@ include::{snippets}/user/signup/http-response.adoc[]
 
 [[COURSE-API]]
 == Course API
+=== 코스생성
+==== Request
+include::{snippets}/course/create/http-request.adoc[]
+==== Response
+include::{snippets}/course/create/http-response.adoc[]
+=== 코스 목록조회
+==== Request
+include::{snippets}/course/getCourseList/http-request.adoc[]
+==== Response
+include::{snippets}/course/getCourseList/http-response.adoc[]
+=== 코스 단건조회
+==== Request
+include::{snippets}/course/getCourse/http-request.adoc[]
+==== Response
+include::{snippets}/course/getCourse/http-response.adoc[]
+=== 코스 수정
+==== Request
+include::{snippets}/course/updateCourse/http-request.adoc[]
+==== Response
+include::{snippets}/course/updateCourse/http-response.adoc[]
+=== 코스 삭제
+==== Request
+include::{snippets}/course/deleteCourse/http-request.adoc[]
+==== Response
+include::{snippets}/course/deleteCourse/http-response.adoc[]
 
 [[CHAT-API]]
 == Chat API

--- a/src/main/java/com/b6/mypaldotrip/domain/course/service/CourseService.java
+++ b/src/main/java/com/b6/mypaldotrip/domain/course/service/CourseService.java
@@ -70,12 +70,13 @@ public class CourseService {
                         .build();
 
         CourseEntity savedCourse = courseRepository.save(course);
-
-        for (String tripName : req.tripNames()) {
-            TripEntity trip = tripService.findTripByName(tripName);
-            TripCourseEntity tripCourse =
-                    TripCourseEntity.builder().trip(trip).course(savedCourse).build();
-            tripCourseRepository.save(tripCourse);
+        if (!req.tripNames().isEmpty()) {
+            for (String tripName : req.tripNames()) {
+                TripEntity trip = tripService.findTripByName(tripName);
+                TripCourseEntity tripCourse =
+                        TripCourseEntity.builder().trip(trip).course(savedCourse).build();
+                tripCourseRepository.save(tripCourse);
+            }
         }
 
         CourseFileEntity courseFileEntity =


### PR DESCRIPTION
## 개요

코스생성시 연관된 여행정보 없이도 생성 가능, RestDocs 아스키독 추가

## 작업사항

- 코스생성시 연관된 여행정보 없이도 생성 가능
- RestDocs 아스키독 추가

## 변경로직

- 내용을 적어주세요.

## 관련 이슈
- 
